### PR TITLE
Import PropTypes and createReactClass

### DIFF
--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var React = require('react');
 var ReactNative = require('react-native');
 var {
@@ -17,22 +19,22 @@ var ScrollableMixin = require('react-native-scrollable-mixin');
 var screen = Dimensions.get('window');
 var ScrollViewPropTypes = ScrollView.propTypes;
 
-var ParallaxView = React.createClass({
+var ParallaxView = createReactClass({
     mixins: [ScrollableMixin],
 
     propTypes: {
         ...ScrollViewPropTypes,
-        windowHeight: React.PropTypes.number,
-        backgroundSource: React.PropTypes.oneOfType([
-          React.PropTypes.shape({
-            uri: React.PropTypes.string,
+        windowHeight: PropTypes.number,
+        backgroundSource: PropTypes.oneOfType([
+          PropTypes.shape({
+            uri: PropTypes.string,
           }),
           // Opaque type returned by require('./image.jpg')
-          React.PropTypes.number,
+          PropTypes.number,
         ]),
-        header: React.PropTypes.node,
-        blur: React.PropTypes.string,
-        contentInset: React.PropTypes.object,
+        header: PropTypes.node,
+        blur: PropTypes.string,
+        contentInset: PropTypes.object,
     },
 
     getDefaultProps: function () {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "homepage": "https://github.com/lelandrichardson/react-native-parallax-view",
   "dependencies": {
+    "create-react-class": "^15.6.2",
+    "prop-types": "^15.6.0",
+    "react": "^16.0.0",
     "react-native-scrollable-mixin": "^1.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
This relates to a breaking change in React 16 where PropTypes and
createClass were removed from React

Fixes #57
Fixes #56